### PR TITLE
Update to Minecraft 1.16.3

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,10 +4,10 @@ mod_id = lowtechcrafting
 mod_file_name = lowtechcrafting
 
 # Current mod version
-mod_version = 0.2.0
+mod_version = 0.2.1
 
 # Minecraft, Forge and MCP mappings versions
-minecraft_version_out = 1.16.1
-minecraft_version = 1.16.1
-forge_version = 32.0.47
+minecraft_version_out = 1.16.3
+minecraft_version = 1.16.3
+forge_version = 34.1.0
 mappings_version = 20200514-1.16

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -7,8 +7,12 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 
+# The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
+# Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
+license="GNU Lesser General Public License" #mandatory
+
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[32,)" #mandatory
+loaderVersion="[34,)" #mandatory
 
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://github.com/maruohon/lowtechcrafting/issues" #optional


### PR DESCRIPTION
Changed forge version to match currently recommended for 1.16.3.
Added the license property to `mods.toml` as it seems to be mandatory now (as Mdk example points it out).

Verified the built jar on both single player world and multiplayer server, crafted some nice melons :)